### PR TITLE
Let AutoNumericInput handle onBlur

### DIFF
--- a/src/lib/AutoNumericInput.tsx
+++ b/src/lib/AutoNumericInput.tsx
@@ -54,17 +54,25 @@ export function AutoNumericInput({
 }): JSX.Element {
   const stateProps =
     valueState !== undefined
-      ? {
+      ? ({
           value: valueState.state,
+          // For input, it is required set value in onChange.
           onChange: (e: ChangeEvent<HTMLInputElement>): void => {
-            // For input, it is required set value in onChange.
             valueState.stateSetter(e.currentTarget.value);
             if (inputProps?.onChange !== undefined) {
               inputProps.onChange(e);
             }
           },
-        }
-      : {};
+          // Some autoNumeric options such as emptyInputBehavior='zero' would not function properly
+          // without onBlur.
+          onBlur: (e): void => {
+            valueState.stateSetter(e.currentTarget.value);
+            if (inputProps?.onBlur !== undefined) {
+              inputProps.onBlur(e);
+            }
+          },
+        } as const satisfies InputProps)
+      : ({} as const);
   return (
     <AutoNumericComponent
       element="input"

--- a/src/test/AutoNumericInput.test.tsx
+++ b/src/test/AutoNumericInput.test.tsx
@@ -156,3 +156,25 @@ test("Changing the input state of AutoNumericInput changes the display value", a
   await user.click(screen.getByRole("button")); // Set the state.
   expect(inputElement).toHaveDisplayValue("1,111.00");
 });
+
+test("AutoNumericInput updates its state upon onBlur", async () => {
+  function TestApp(): JSX.Element {
+    const [state, setState] = useState("1");
+    return (
+      <>
+        <AutoNumericInput
+          valueState={{ state, stateSetter: setState }}
+          autoNumericOptions={{ emptyInputBehavior: "zero" }}
+        />
+      </>
+    );
+  }
+
+  const user = userEvent.setup();
+  render(<TestApp />);
+
+  const inputElement = screen.getByRole("textbox");
+  await user.clear(inputElement);
+  await user.keyboard("{Tab}");
+  expect(inputElement).toHaveDisplayValue("0.00");
+});


### PR DESCRIPTION
Otherwise, some AutoNumeric options such as emptyInputBehavior='zero' would not work properly.