### PR TITLE
Require ref to be absent from AutoNumericInput props.

### DIFF
--- a/src/lib/AutoNumericInput.tsx
+++ b/src/lib/AutoNumericInput.tsx
@@ -20,10 +20,8 @@ import { AutoNumericComponent } from "./AutoNumericComponent.js";
 import type { CallbackOptions } from "autonumeric";
 
 /** Same as {@link JSX!IntrinsicElements.input.props} excluding the `ref` property. */
-export type InputProps = Omit<
-  InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement>,
-  "ref"
->;
+export type InputProps = InputHTMLAttributes<HTMLInputElement> &
+  ClassAttributes<HTMLInputElement> & { ref?: undefined };
 
 /** React {@link JSX!IntrinsicElements.input} component integrated with {@link !AutoNumeric} and
  * permits interaction with a React state.


### PR DESCRIPTION
It would conflict with its internal handling of refs.